### PR TITLE
Refresh profile projects and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
-  
 # Rudrank Riyam
 
-## Projects
+I build Swift packages and command-line tools for Apple platforms, with a focus on on-device AI, Foundation Models, and developer automation. Creator of [App Store Connect CLI](https://github.com/rorkai/App-Store-Connect-CLI), acquired by [Rork](https://github.com/rorkai).
 
-- [**Foundation-Models-Framework-Example**](https://github.com/rudrankriyam/Foundation-Models-Framework-Example) - Example apps for Foundation Models Framework in iOS 26 and macOS 26
-- [**App-Store-Connect-CLI**](https://github.com/rudrankriyam/App-Store-Connect-CLI) - Fast, AI-agent friendly CLI for App Store Connect. Ship apps with zero friction.
+## Shipped in June 2026
 
-## Packages
+- [**xceval 0.2.1**](https://github.com/rudrankriyam/Evaluations-Framework-CLI/releases/tag/0.2.1) - Unofficial CLI for Apple Evaluations workflows: scaffold evaluation projects, run producers and Xcode tests, inspect and compare results, export data, validate collections, and enforce CI gates.
+- [**Foundation Models Framework Lab 0.3.0**](https://github.com/rudrankriyam/Foundation-Models-Framework-Lab/releases/tag/0.3.0) - The canonical Xcode 27 workspace for Foundation Models examples, `FoundationModelsKit`, the `afm` CLI, AppBench, Adapter Studio, and macOS Evaluations workflows.
+- [**MusaveraKit 0.1.0**](https://github.com/rryam/MusaveraKit/releases/tag/0.1.0) - App-friendly Swift APIs and a macOS lab for Apple's on-device Music Understanding framework.
+- [**RelatoKit 0.2.0**](https://github.com/rryam/RelatoKit/releases/tag/0.2.0) - Local-first Swift CLI and library for preparing Feedback Assistant reports and handing them off to the native macOS app.
+- [**Core AI Framework Lab**](https://github.com/rudrankriyam/Core-AI-Framework-Lab) - Compiler-first examples and SDK notes for Apple's new `CoreAI.framework` in Xcode 27.
+- [**CoreAgent 0.1.0**](https://github.com/rudrankriyam/CoreAgent/releases/tag/0.1.0) - Swift runtime for on-device agents with tools, memory, approval gates, traces, receipts, and Foundation Models integration.
+- [**FoundationModelsKit 2.0.0**](https://github.com/rryam/FoundationModelsKit/releases/tag/2.0.0) - Transcript history transforms and summarization helpers. Stable releases remain available, with active development moved into Foundation Models Framework Lab.
+- [**AuralKit 2.0.0**](https://github.com/rryam/AuralKit/releases/tag/2.0.0) and [**VecturaMLXKit 3.0.2**](https://github.com/rryam/VecturaMLXKit/releases/tag/3.0.2) - Xcode 27 speech transcription support and MLX tokenizer compatibility updates.
+- [**App Store Connect CLI 2.0.0**](https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/2.0.0) - App Store Connect API 4.4 coverage, individual API keys, Xcode deployment metadata, and Windows distribution.
 
-- [**MusadoraKit**](https://github.com/rryam/MusadoraKit) - The ultimate companion to MusicKit.
-- [**VecturaKit**](https://github.com/rryam/VecturaKit) - Swift-based vector database for on-device RAG using MLTensor and MLX Embedders
-- [**ErabiKit**](https://github.com/rryam/ErabiKit) - A beautiful customizable settings screen created in SwiftUI
-- [**MeshingKit**](https://github.com/rryam/MeshingKit) - Ultimate framework to add mesh gradients to your iOS/macOS/visionOS/tvOS and watchOS apps!
-- [**FoundationModelsKit**](https://github.com/rryam/FoundationModelsKit) - Community made tools to directly use it in your app with Foundation Models framework
-- [**AuralKit**](https://github.com/rryam/AuralKit) - Easily use SpeechAnalyzerAPI
-- [**MLX-Outil**](https://github.com/rudrankriyam/MLX-Outil) - Tool calling using MLX Swift across iOS, macOS, and visionOS platforms
-- [**LumoKit**](https://github.com/rryam/LumoKit) - Swift package for on-device Retrieval-Augmented Generation (RAG)
-- [**LiquidGlasKit**](https://github.com/rryam/LiquidGlasKit) - A Swift package providing customizable modifiers for easy liquid glass effects and materials in SwiftUI applications
-- [**MusanovaKit**](https://github.com/rryam/MusanovaKit) - Explore and experiment with private Apple Music API endpoints.
+## More Swift Packages
+
+- [**MusadoraKit**](https://github.com/rryam/MusadoraKit) - A companion package for MusicKit.
+- [**VecturaKit**](https://github.com/rryam/VecturaKit) - An on-device vector database for RAG using MLTensor and MLX embedders.
+- [**MeshingKit**](https://github.com/rryam/MeshingKit) - Mesh gradients for SwiftUI across Apple platforms.
+- [**LumoKit**](https://github.com/rryam/LumoKit) - On-device retrieval-augmented generation for Swift apps.
+- [**MLX-Outil**](https://github.com/rudrankriyam/MLX-Outil) - Tool calling with MLX Swift across iOS, macOS, and visionOS.
+- [**ErabiKit**](https://github.com/rryam/ErabiKit) - Customizable settings screens built with SwiftUI.
+- [**LiquidGlasKit**](https://github.com/rryam/LiquidGlasKit) - SwiftUI modifiers for liquid glass effects and materials.
+- [**MusanovaKit**](https://github.com/rryam/MusanovaKit) - Experiments with private Apple Music API endpoints.

--- a/README.md
+++ b/README.md
@@ -2,22 +2,26 @@
 
 I build Swift packages and command-line tools for Apple platforms, with a focus on on-device AI, Foundation Models, and developer automation. Creator of [App Store Connect CLI](https://github.com/rorkai/App-Store-Connect-CLI), acquired by [Rork](https://github.com/rorkai).
 
-## Shipped in June 2026
+## Developer Tools
 
-- [**xceval 0.2.1**](https://github.com/rudrankriyam/Evaluations-Framework-CLI/releases/tag/0.2.1) - Unofficial CLI for Apple Evaluations workflows: scaffold evaluation projects, run producers and Xcode tests, inspect and compare results, export data, validate collections, and enforce CI gates.
-- [**Foundation Models Framework Lab 0.3.0**](https://github.com/rudrankriyam/Foundation-Models-Framework-Lab/releases/tag/0.3.0) - The canonical Xcode 27 workspace for Foundation Models examples, `FoundationModelsKit`, the `afm` CLI, AppBench, Adapter Studio, and macOS Evaluations workflows.
-- [**MusaveraKit 0.1.0**](https://github.com/rryam/MusaveraKit/releases/tag/0.1.0) - App-friendly Swift APIs and a macOS lab for Apple's on-device Music Understanding framework.
-- [**RelatoKit 0.2.0**](https://github.com/rryam/RelatoKit/releases/tag/0.2.0) - Local-first Swift CLI and library for preparing Feedback Assistant reports and handing them off to the native macOS app.
-- [**Core AI Framework Lab**](https://github.com/rudrankriyam/Core-AI-Framework-Lab) - Compiler-first examples and SDK notes for Apple's new `CoreAI.framework` in Xcode 27.
-- [**CoreAgent 0.1.0**](https://github.com/rudrankriyam/CoreAgent/releases/tag/0.1.0) - Swift runtime for on-device agents with tools, memory, approval gates, traces, receipts, and Foundation Models integration.
-- [**FoundationModelsKit 2.0.0**](https://github.com/rryam/FoundationModelsKit/releases/tag/2.0.0) - Transcript history transforms and summarization helpers. Stable releases remain available, with active development moved into Foundation Models Framework Lab.
-- [**AuralKit 2.0.0**](https://github.com/rryam/AuralKit/releases/tag/2.0.0) and [**VecturaMLXKit 3.0.2**](https://github.com/rryam/VecturaMLXKit/releases/tag/3.0.2) - Xcode 27 speech transcription support and MLX tokenizer compatibility updates.
-- [**App Store Connect CLI 2.0.0**](https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/2.0.0) - App Store Connect API 4.4 coverage, individual API keys, Xcode deployment metadata, and Windows distribution.
+- [**App Store Connect CLI**](https://github.com/rorkai/App-Store-Connect-CLI) - Fast, scriptable CLI for TestFlight, builds, submissions, signing, analytics, screenshots, subscriptions, Apple Ads, and more.
+- [**xceval**](https://github.com/rudrankriyam/Evaluations-Framework-CLI) - Unofficial CLI for Apple Evaluations workflows: scaffold projects, run producers and Xcode tests, inspect and compare results, export data, validate collections, and enforce CI gates.
+- [**RelatoKit**](https://github.com/rryam/RelatoKit) - Local-first Swift CLI and library for preparing Feedback Assistant reports and handing them off to the native macOS app.
 
-## More Swift Packages
+## Labs and Runtimes
 
+- [**Foundation Models Framework Lab**](https://github.com/rudrankriyam/Foundation-Models-Framework-Lab) - Practical Xcode workspace for Foundation Models examples, `FoundationModelsKit`, the `afm` CLI, AppBench, Adapter Studio, and Evaluations workflows.
+- [**Core AI Framework Lab**](https://github.com/rudrankriyam/Core-AI-Framework-Lab) - Compiler-first examples and SDK notes for Apple's lower-level `CoreAI.framework`.
+- [**CoreAgent**](https://github.com/rudrankriyam/CoreAgent) - Swift runtime for on-device agents with tools, memory, approval gates, traces, receipts, and Foundation Models integration.
+
+## Swift Packages
+
+- [**MusaveraKit**](https://github.com/rryam/MusaveraKit) - App-friendly Swift APIs for Apple's on-device Music Understanding framework.
+- [**AuralKit**](https://github.com/rryam/AuralKit) - Real-time and file-based transcription with SpeechAnalyzer and SpeechTranscriber.
+- [**FoundationModelsKit**](https://github.com/rryam/FoundationModelsKit) - Foundation Models utilities and transcript helpers. Stable releases remain here, with active development in Foundation Models Framework Lab.
 - [**MusadoraKit**](https://github.com/rryam/MusadoraKit) - A companion package for MusicKit.
 - [**VecturaKit**](https://github.com/rryam/VecturaKit) - An on-device vector database for RAG using MLTensor and MLX embedders.
+- [**VecturaMLXKit**](https://github.com/rryam/VecturaMLXKit) - GPU-accelerated MLX embeddings for VecturaKit.
 - [**MeshingKit**](https://github.com/rryam/MeshingKit) - Mesh gradients for SwiftUI across Apple platforms.
 - [**LumoKit**](https://github.com/rryam/LumoKit) - On-device retrieval-augmented generation for Swift apps.
 - [**MLX-Outil**](https://github.com/rudrankriyam/MLX-Outil) - Tool calling with MLX Swift across iOS, macOS, and visionOS.


### PR DESCRIPTION
## Summary

- organize the profile as an evergreen portfolio of developer tools, labs and runtimes, and Swift packages
- add xceval, RelatoKit, MusaveraKit, Core AI Framework Lab, CoreAgent, and VecturaMLXKit
- point App Store Connect CLI to its current Rork repository and remove the old agent-friendly claim
- replace the archived Foundation Models example link with the consolidated Foundation Models Framework Lab
- retain established packages with clearer, factual descriptions and note where FoundationModelsKit development now lives

## Verification

- reviewed current public repositories, release metadata, and ownership before selecting projects
- rendered the README through GitHub's Markdown API
- verified all 19 repository links return HTTP 200
- confirmed the README contains no timeline or version framing
- ran `git diff --check`